### PR TITLE
Add children prop to the standAloneTextfield component

### DIFF
--- a/src/components/Inputs/ColorPicker/ColorPicker.scss
+++ b/src/components/Inputs/ColorPicker/ColorPicker.scss
@@ -1,18 +1,13 @@
 @use "./ColorPicker.theme.scss";
 
 .m-color-picker-container {
-  .m-color-preview-container {
-    display: flex;
-    gap: var(--spacing-2);
+  .m-color-preview {
+    height: var(--input-height);
+    box-sizing: border-box;
+    border-radius: var(--radius-md);
+  }
 
-    .m-color-preview {
-      height: var(--input-height);
-      box-sizing: border-box;
-      border-radius: var(--radius-md);
-    }
-
-    .m-color-preview-square {
-      --square-size: var(--input-height);
-    }
+  .m-color-preview-square {
+    --square-size: var(--input-height);
   }
 }

--- a/src/components/Inputs/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/Inputs/ColorPicker/ColorPicker.stories.tsx
@@ -34,7 +34,7 @@ export default meta;
 
 type Story = StoryObj<typeof ColorPicker>;
 
-export const Default: Story = { args: { value: "red" } };
+export const Default: Story = { args: {} };
 export const Label: Story = { args: { label: "Input label", labelType: "left" } };
 export const Size: Story = { args: { size: "small" } };
 export const Error: Story = { args: { error: "Input error" } };

--- a/src/components/Inputs/ColorPicker/ColorPickerPopup/ColorPickerPopup.tsx
+++ b/src/components/Inputs/ColorPicker/ColorPickerPopup/ColorPickerPopup.tsx
@@ -10,12 +10,13 @@ import { RgbValue } from "../types";
 import { ColorPickerCanvas } from "./ColorPickerCanvas/ColorPickerCanvas";
 
 import { useKeyboardClose, useOutsideClick } from "../../../../hooks";
+
 import "./ColorPickerPopup.scss";
 
 type ColorPickerPopupProps = {
   value: RgbValue | null;
   onChange: (value: RgbValue) => void;
-  parentElement: HTMLInputElement;
+  parentElement: HTMLDivElement;
   className: string;
   handleClose: (value: RgbValue) => void;
 };
@@ -35,7 +36,6 @@ export const ColorPickerPopup = ({ value, onChange, parentElement, className, ha
 
       return (
         originalOutsideClickTriggerCondition &&
-        !parentElement.contains(target) &&
         !(target.className.includes("m-color-preview-square") || target.className.includes("m-color-preview"))
       );
     },
@@ -43,7 +43,7 @@ export const ColorPickerPopup = ({ value, onChange, parentElement, className, ha
 
   useLayoutEffect(() => {
     const calculatePopupPosition = () => {
-      setPosition(getPosition(parentElement, popupRef.current));
+      setPosition(getPosition(parentElement.querySelector(".m-color-preview-square"), popupRef.current));
     };
 
     const resizeObserver = new ResizeObserver(calculatePopupPosition);

--- a/src/components/Inputs/ColorPicker/types.tsx
+++ b/src/components/Inputs/ColorPicker/types.tsx
@@ -1,15 +1,15 @@
 import { MInputChangeEvent } from "../../../types/MInputChangeEvent";
 import { InputProps } from "../_inputsComponents/input-types";
+import { StandAloneTextfieldClassNames } from "../_inputsComponents/StandAloneTextfield/types";
 
 export type ColorValue = HslValue | RgbValue | string;
 
 type ColorPickerClassNames = {
-  container?: string;
-  input?: string;
-  label?: string;
-  error?: string;
-  popup?: string;
-};
+  containerClassName?: string;
+  labelClassName?: string;
+  errorClassName?: string;
+  popupClassName?: string;
+} & StandAloneTextfieldClassNames;
 
 export type ColorPickerChangeEvent<TReturnedColor extends ReturnedColor> = TReturnedColor extends ReturnedColor.RGB
   ? MInputChangeEvent<RgbValue>

--- a/src/components/Inputs/DateField/DateField.tsx
+++ b/src/components/Inputs/DateField/DateField.tsx
@@ -55,7 +55,7 @@ export const DateField = <TRange extends boolean = false>(props: DateFieldProps<
     placeholder = undefined,
     label = undefined,
     error = undefined,
-    classNamesObj,
+    classNamesObj = {},
 
     locale = "en-US",
     range = false as TRange,
@@ -150,11 +150,14 @@ export const DateField = <TRange extends boolean = false>(props: DateFieldProps<
 
   const datefieldElement = document.getElementById(`textfield-${uniqueDatefieldId}`) as HTMLInputElement | null;
 
+  const { containerClassName, labelClassName, errorClassName, popupClassName, ...standAloneTextfieldClassNames } =
+    classNamesObj;
+
   return (
     <InputContainer
       ref={dateFieldContainerRef}
       disabled={disabled}
-      className={classNames("m-datefield-container", classNamesObj?.container)}
+      className={classNames("m-datefield-container", containerClassName)}
       size={size}
       error={error}
       marginBottomType={marginBottomType}
@@ -167,7 +170,7 @@ export const DateField = <TRange extends boolean = false>(props: DateFieldProps<
         placeholder={labelType === InputLabel.FLOATING ? undefined : placeholder || (label ? `${label}...` : "")}
         style={getInputStyle(labelType, label, labelWidth, floatingInputWidth)}
         disabled={disabled}
-        className={classNamesObj?.input}
+        classNamesObj={standAloneTextfieldClassNames}
         value={
           Array.isArray(value)
             ? `${value[0]?.toLocaleDateString(locale) ?? ""} - ${value[1]?.toLocaleDateString(locale) ?? ""}`
@@ -181,7 +184,7 @@ export const DateField = <TRange extends boolean = false>(props: DateFieldProps<
         <InputsLabel
           label={label}
           labelType={labelType}
-          className={classNames("m-datefield-label", classNamesObj?.label)}
+          className={classNames("m-datefield-label", labelClassName)}
           labelWidth={labelWidth}
           isFocused={isFocused}
           isFilled={!!value}
@@ -190,7 +193,7 @@ export const DateField = <TRange extends boolean = false>(props: DateFieldProps<
       {error && (
         <InputError
           style={getInputsErrorStyle(labelType, labelWidth, floatingInputWidth)}
-          className={classNames("datefield-error", classNamesObj?.error)}
+          className={classNames("datefield-error", errorClassName)}
           error={error}
         />
       )}
@@ -203,7 +206,7 @@ export const DateField = <TRange extends boolean = false>(props: DateFieldProps<
             locale={locale}
             value={value}
             onChange={handleChange}
-            className={classNames(openStatus, classNamesObj?.popup)}
+            className={classNames(openStatus, popupClassName)}
             parentElement={datefieldElement}
             handleBlur={handleBlur}
           />,

--- a/src/components/Inputs/DateField/DatePickerPopup/DatePickerPopup.tsx
+++ b/src/components/Inputs/DateField/DatePickerPopup/DatePickerPopup.tsx
@@ -276,8 +276,8 @@ export const DatePickerPopup = <TRange extends boolean>({
             onChange={handleMonthChange}
             options={monthsOptions}
             classNamesObj={{
-              container: "date-picker-popup-dropdown-container",
-              dropdownOptions: "date-picker-popup-dropdown-options",
+              containerClassName: "date-picker-popup-dropdown-container",
+              dropdownOptionsClassName: "date-picker-popup-dropdown-options",
             }}
             optionHeightFit={8}
             marginBottomType="none"
@@ -289,8 +289,8 @@ export const DatePickerPopup = <TRange extends boolean>({
             onChange={handleYearChange}
             options={yearsOptions}
             classNamesObj={{
-              container: "date-picker-popup-dropdown-container",
-              dropdownOptions: "date-picker-popup-dropdown-options",
+              containerClassName: "date-picker-popup-dropdown-container",
+              dropdownOptionsClassName: "date-picker-popup-dropdown-options",
             }}
             optionHeightFit={8}
             marginBottomType="none"

--- a/src/components/Inputs/DateField/types.ts
+++ b/src/components/Inputs/DateField/types.ts
@@ -2,14 +2,14 @@ import { FocusEvent } from "react";
 
 import { MInputChangeEvent } from "../../../types/MInputChangeEvent";
 import { InputProps } from "../_inputsComponents/input-types";
+import { StandAloneTextfieldClassNames } from "../_inputsComponents/StandAloneTextfield/types";
 
 type DateFieldClassNames = {
-  container?: string;
-  input?: string;
-  label?: string;
-  error?: string;
-  popup?: string;
-};
+  containerClassName?: string;
+  labelClassName?: string;
+  errorClassName?: string;
+  popupClassName?: string;
+} & StandAloneTextfieldClassNames;
 
 export type ParsableSingleDate = string | Date;
 export type ParsableRangeDate = [ParsableSingleDate | null, ParsableSingleDate | null];

--- a/src/components/Inputs/Dropdown/Dropdown.tsx
+++ b/src/components/Inputs/Dropdown/Dropdown.tsx
@@ -90,7 +90,7 @@ function Dropdown<T extends { [key: string]: unknown } = LabelValue>({
   placeholder,
   label,
   error,
-  classNamesObj,
+  classNamesObj = {},
 
   prefix,
   options = [],
@@ -250,6 +250,20 @@ function Dropdown<T extends { [key: string]: unknown } = LabelValue>({
     | null
     | undefined;
 
+  const {
+    controlClassName,
+    clearIconClassName,
+    dropdownIndicatorIconClassName,
+    dropdownOptionsClassName,
+    dropdownOptionClassName,
+    emptyDropdownOptionClassName,
+    containerClassName,
+    labelClassName,
+    errorClassName,
+    standAloneTextfieldContainerClassName,
+    prefixClassName,
+  } = classNamesObj;
+
   const controlProps: StandAloneTextfieldProps = {
     disabled: disabled,
     id: uniqueDropdownId,
@@ -261,20 +275,24 @@ function Dropdown<T extends { [key: string]: unknown } = LabelValue>({
     onFocus: handleFocus,
     placeholder: labelType === InputLabel.FLOATING ? undefined : placeholder || (label ? `${label}...` : ""),
     prefix: prefix,
-    className: classNames("m-dropdown-control", classNamesObj?.control, labelType, {
-      "read-only": readOnly,
-      filtrable: filter,
-    }),
+    classNamesObj: {
+      inputClassName: classNames("m-dropdown-control", controlClassName, labelType, {
+        "read-only": readOnly,
+        filtrable: filter,
+      }),
+      standAloneTextfieldContainerClassName,
+      prefixClassName,
+    },
     style: { ...getInputStyle(labelType, label, labelWidth, floatingInputWidth) },
   };
 
   const clearIconProps: ClearIconProps = {
-    className: classNames("m-dropdown-icon", "m-dropdown-clear-icon", classNamesObj?.clearIcon),
+    className: classNames("m-dropdown-icon", "m-dropdown-clear-icon", clearIconClassName),
     onClick: handleClear,
   };
 
   const indicatorIconProps: IndicatorIconProps = {
-    className: classNames("m-dropdown-icon", "m-dropdown-indicator-icon", classNamesObj?.dropdownIndicatorIcon),
+    className: classNames("m-dropdown-icon", "m-dropdown-indicator-icon", dropdownIndicatorIconClassName),
     onClick: () => setIsFocused(!isFocused),
   };
 
@@ -294,16 +312,16 @@ function Dropdown<T extends { [key: string]: unknown } = LabelValue>({
     EmptyMessage: currentComponents.EmptyMessage,
 
     classNamesObj: {
-      dropdownOptions: classNamesObj?.dropdownOptions,
-      dropdownOption: classNamesObj?.dropdownOption,
-      emptyDropdownOption: classNamesObj?.emptyDropdownOption,
+      dropdownOptionsClassName,
+      dropdownOptionClassName,
+      emptyDropdownOptionClassName,
     },
   };
 
   return (
     <InputContainer
       disabled={disabled}
-      className={classNames("m-dropdown-container", classNamesObj?.container)}
+      className={classNames("m-dropdown-container", containerClassName)}
       size={size}
       error={error}
       ref={controlContainerRef}
@@ -315,7 +333,7 @@ function Dropdown<T extends { [key: string]: unknown } = LabelValue>({
         <InputsLabel
           label={label}
           labelType={labelType}
-          className={classNames("m-dropdown-label", classNamesObj?.label)}
+          className={classNames("m-dropdown-label", labelClassName)}
           labelWidth={labelWidth}
           isFocused={isFocused}
           isFilled={!!value}
@@ -331,7 +349,7 @@ function Dropdown<T extends { [key: string]: unknown } = LabelValue>({
       {error ? (
         <InputError
           style={getInputsErrorStyle(labelType, labelWidth, floatingInputWidth)}
-          className={classNames("dropdown-error", classNamesObj?.error)}
+          className={classNames("dropdown-error", errorClassName)}
           error={error}
         />
       ) : (

--- a/src/components/Inputs/Dropdown/DropdownOptionsComponent/DropdownOptionsComponent.tsx
+++ b/src/components/Inputs/Dropdown/DropdownOptionsComponent/DropdownOptionsComponent.tsx
@@ -80,7 +80,7 @@ export const DropdownOptionsComponent = <T,>({
 
   const emptyMessageProps: EmptyMessageComponentProps = {
     id,
-    className: classNames("m-dropdown-option empty-message", classNamesObj?.emptyDropdownOption),
+    className: classNames("m-dropdown-option empty-message", classNamesObj?.emptyDropdownOptionClassName),
     noOptionsMessage,
   };
 
@@ -88,13 +88,13 @@ export const DropdownOptionsComponent = <T,>({
     <ul
       id={`dropdown-option-${id}`}
       ref={ref}
-      className={classNames("m-dropdown-options", "m-scroll slim-scroll", classNamesObj?.dropdownOptions)}
+      className={classNames("m-dropdown-options", "m-scroll slim-scroll", classNamesObj?.dropdownOptionsClassName)}
       style={dropdownOptionsStyles}
     >
       {options && options.length > 0
         ? options.map((option) => {
             const optionProps: DropdownOptionComponentProps<T> = {
-              className: classNames("m-dropdown-option", "truncate-text", classNamesObj?.dropdownOption, {
+              className: classNames("m-dropdown-option", "truncate-text", classNamesObj?.dropdownOptionClassName, {
                 selected: option[valueKey] === value?.[valueKey],
               }),
               option,

--- a/src/components/Inputs/Dropdown/types.ts
+++ b/src/components/Inputs/Dropdown/types.ts
@@ -4,16 +4,20 @@ import { MInputChangeEvent } from "../../../types/MInputChangeEvent";
 import { GetPositionConfig } from "../../../utils";
 import { InputProps } from "../_inputsComponents/input-types";
 import { StandAloneTextfield } from "../_inputsComponents/StandAloneTextfield/StandAloneTextfield";
-import { StandAloneTextfieldProps } from "../_inputsComponents/StandAloneTextfield/types";
+import {
+  StandAloneTextfieldClassNames,
+  StandAloneTextfieldProps,
+} from "../_inputsComponents/StandAloneTextfield/types";
 
 type DropdownClassNames = {
-  container?: string;
-  control?: string;
-  label?: string;
-  error?: string;
-  dropdownIndicatorIcon?: string;
-  clearIcon?: string;
-} & DropdownOptionsClassnames;
+  containerClassName?: string;
+  controlClassName?: string;
+  labelClassName?: string;
+  errorClassName?: string;
+  dropdownIndicatorIconClassName?: string;
+  clearIconClassName?: string;
+} & DropdownOptionsClassnames &
+  Omit<StandAloneTextfieldClassNames, "inputClassName">;
 
 export type DropdownChangeEvent<T> = React.MouseEvent<HTMLLIElement, MouseEvent> & MInputChangeEvent<T>;
 export type DropdownBlurEvent<T> = MInputChangeEvent<DropdownValue<T>>;
@@ -120,9 +124,9 @@ type LabelValue = {
 };
 
 type DropdownOptionsClassnames = {
-  dropdownOptions?: string;
-  dropdownOption?: string;
-  emptyDropdownOption?: string;
+  dropdownOptionsClassName?: string;
+  dropdownOptionClassName?: string;
+  emptyDropdownOptionClassName?: string;
 };
 
 export type DropdownOptionsProps<T> = {

--- a/src/components/Inputs/IconField/IconField.scss
+++ b/src/components/Inputs/IconField/IconField.scss
@@ -9,37 +9,31 @@
   }
 }
 
-.m-icon-preview-container {
-  display: flex;
+.m-icon-preview-square {
+  --square-size: var(--input-height);
+  transition: var(--transition-duration-normal);
 
-  gap: var(--spacing-2);
-
-  .m-icon-preview-square {
-    --square-size: var(--input-height);
-    transition: var(--transition-duration-normal);
-
-    &:hover {
-      .m-icon-preview {
-        display: none;
-      }
-
-      .m-clear-icon {
-        display: initial;
-      }
+  &:hover {
+    .m-icon-preview {
+      display: none;
     }
 
     .m-clear-icon {
-      display: none;
-      transition: var(--transition-duration-normal);
+      display: initial;
+    }
+  }
 
-      &:hover {
-        transform: scale(1.1);
-      }
+  .m-clear-icon {
+    display: none;
+    transition: var(--transition-duration-normal);
 
-      &:active {
-        transform: scale(0.9);
-        transition: var(--transition-duration-fast);
-      }
+    &:hover {
+      transform: scale(1.1);
+    }
+
+    &:active {
+      transform: scale(0.9);
+      transition: var(--transition-duration-fast);
     }
   }
 }

--- a/src/components/Inputs/IconField/types.ts
+++ b/src/components/Inputs/IconField/types.ts
@@ -1,14 +1,14 @@
 import { MInputChangeEvent } from "../../../types/MInputChangeEvent";
 import { InputProps } from "../_inputsComponents/input-types";
+import { StandAloneTextfieldClassNames } from "../_inputsComponents/StandAloneTextfield/types";
 import { ColorValue } from "../ColorPicker";
 
 type IconFieldClassNames = {
-  container?: string;
-  input?: string;
-  label?: string;
-  error?: string;
-  popup?: string;
-};
+  containerClassName?: string;
+  labelClassName?: string;
+  errorClassName?: string;
+  popupClassName?: string;
+} & StandAloneTextfieldClassNames;
 
 export type IconFieldChangeEvent = React.MouseEvent<HTMLDivElement, MouseEvent> & MInputChangeEvent;
 export type IconFieldBlurEvent = MInputChangeEvent<string | null>;

--- a/src/components/Inputs/NumberField/NumberField.tsx
+++ b/src/components/Inputs/NumberField/NumberField.tsx
@@ -33,7 +33,7 @@ const NumberField = (props: NumberFieldProps) => {
     placeholder = undefined,
     label = undefined,
     error = undefined,
-    classNamesObj,
+    classNamesObj = {},
     debounceDelay = 300,
     name,
     persistEvent = false,
@@ -113,10 +113,12 @@ const NumberField = (props: NumberFieldProps) => {
     onBlur(convertedEvent, parsedValue);
   };
 
+  const { containerClassName, labelClassName, errorClassName, ...standAloneTextfieldClassNames } = classNamesObj;
+
   return (
     <InputContainer
       disabled={disabled}
-      className={classNames("m-numberfield-container", classNamesObj?.container)}
+      className={classNames("m-numberfield-container", containerClassName)}
       size={size}
       error={error}
       marginBottomType={marginBottomType}
@@ -132,7 +134,7 @@ const NumberField = (props: NumberFieldProps) => {
         placeholder={labelType === InputLabel.FLOATING ? undefined : placeholder || (label ? `${label}...` : "")}
         style={getInputStyle(labelType, label, labelWidth, floatingInputWidth)}
         disabled={disabled}
-        className={classNamesObj?.input}
+        classNamesObj={standAloneTextfieldClassNames}
         value={displayValue}
         size={size}
         type="number"
@@ -142,7 +144,7 @@ const NumberField = (props: NumberFieldProps) => {
         <InputsLabel
           label={label}
           labelType={labelType}
-          className={classNames("m-numberfield-label", classNamesObj?.label)}
+          className={classNames("m-numberfield-label", labelClassName)}
           labelWidth={labelWidth}
           isFocused={isFocused}
           isFilled={!!displayValue}
@@ -152,7 +154,7 @@ const NumberField = (props: NumberFieldProps) => {
       {error && (
         <InputError
           style={getInputsErrorStyle(labelType, labelWidth, floatingInputWidth)}
-          className={classNames("numberfield-error", classNamesObj?.error)}
+          className={classNames("numberfield-error", errorClassName)}
           error={error}
         />
       )}

--- a/src/components/Inputs/NumberField/types.ts
+++ b/src/components/Inputs/NumberField/types.ts
@@ -1,15 +1,18 @@
 import { ChangeEvent, FocusEvent } from "react";
 
 import { MInputChangeEvent } from "../../../types/MInputChangeEvent";
-import { StandAloneTextfieldProps } from "../_inputsComponents/StandAloneTextfield/types";
 import { InputProps } from "../_inputsComponents/input-types";
 
+import {
+  StandAloneTextfieldClassNames,
+  StandAloneTextfieldProps,
+} from "../_inputsComponents/StandAloneTextfield/types";
+
 type NumberFieldClassNames = {
-  container?: string;
-  input?: string;
-  label?: string;
-  error?: string;
-};
+  containerClassName?: string;
+  labelClassName?: string;
+  errorClassName?: string;
+} & StandAloneTextfieldClassNames;
 
 export type NumberFieldChangeEvent = ChangeEvent<HTMLInputElement> & MInputChangeEvent<number | null>;
 

--- a/src/components/Inputs/Textfield/Textfield.tsx
+++ b/src/components/Inputs/Textfield/Textfield.tsx
@@ -26,7 +26,7 @@ const Textfield = (props: TextfieldProps) => {
     placeholder = undefined,
     label = undefined,
     error = undefined,
-    classNamesObj,
+    classNamesObj = {},
     debounceDelay = 300,
 
     labelType = defaultInputPropsValue.labelType,
@@ -70,10 +70,12 @@ const Textfield = (props: TextfieldProps) => {
     onBlur && onBlur(e, e.target.value);
   };
 
+  const { containerClassName, labelClassName, errorClassName, ...standAloneTextfieldClassNames } = classNamesObj;
+
   return (
     <InputContainer
       disabled={disabled}
-      className={classNames("m-textfield-container", classNamesObj?.container)}
+      className={classNames("m-textfield-container", containerClassName)}
       size={size}
       error={error}
       marginBottomType={marginBottomType}
@@ -87,7 +89,7 @@ const Textfield = (props: TextfieldProps) => {
         placeholder={labelType === InputLabel.FLOATING ? undefined : placeholder || (label ? `${label}...` : "")}
         style={getInputStyle(labelType, label, labelWidth, floatingInputWidth)}
         disabled={disabled}
-        className={classNamesObj?.input}
+        classNamesObj={standAloneTextfieldClassNames}
         value={value}
         size={size}
         {...otherProps}
@@ -96,7 +98,7 @@ const Textfield = (props: TextfieldProps) => {
         <InputsLabel
           label={label}
           labelType={labelType}
-          className={classNames("m-textfield-label", classNamesObj?.label)}
+          className={classNames("m-textfield-label", labelClassName)}
           labelWidth={labelWidth}
           isFocused={isFocused}
           isFilled={!!value}
@@ -106,7 +108,7 @@ const Textfield = (props: TextfieldProps) => {
       {error && (
         <InputError
           style={getInputsErrorStyle(labelType, labelWidth, floatingInputWidth)}
-          className={classNames("textfield-error", classNamesObj?.error)}
+          className={classNames("textfield-error", errorClassName)}
           error={error}
         />
       )}

--- a/src/components/Inputs/Textfield/types.ts
+++ b/src/components/Inputs/Textfield/types.ts
@@ -1,15 +1,18 @@
 import { ChangeEvent, FocusEvent } from "react";
 
+import {
+  StandAloneTextfieldClassNames,
+  StandAloneTextfieldProps,
+} from "../_inputsComponents/StandAloneTextfield/types";
+
 import { MInputChangeEvent } from "../../../types/MInputChangeEvent";
-import { StandAloneTextfieldProps } from "../_inputsComponents/StandAloneTextfield/types";
 import { InputProps } from "../_inputsComponents/input-types";
 
 type TextFieldClassNames = {
-  container?: string;
-  input?: string;
-  label?: string;
-  error?: string;
-};
+  containerClassName?: string;
+  labelClassName?: string;
+  errorClassName?: string;
+} & StandAloneTextfieldClassNames;
 
 export type TextFieldChangeEvent = ChangeEvent<HTMLInputElement> & MInputChangeEvent;
 

--- a/src/components/Inputs/_inputsComponents/StandAloneTextfield/StandAloneTextfield.tsx
+++ b/src/components/Inputs/_inputsComponents/StandAloneTextfield/StandAloneTextfield.tsx
@@ -11,6 +11,20 @@ type PrefixStyleProperties = {
   prefixLeftPosition?: string;
 };
 
+const getChildrenComponentWidth = (leftChildrenComponent: HTMLElement | null): number => {
+  if (leftChildrenComponent === null) {
+    return 0;
+  }
+
+  const leftChildrenComponentStyles = window.getComputedStyle(leftChildrenComponent);
+
+  return (
+    parseFloat(leftChildrenComponentStyles.width) +
+    parseFloat(leftChildrenComponentStyles.marginLeft) +
+    parseFloat(leftChildrenComponentStyles.marginRight)
+  );
+};
+
 export const StandAloneTextfield = ({
   value = undefined,
   name = undefined,
@@ -20,7 +34,7 @@ export const StandAloneTextfield = ({
   id = undefined,
   idPrefix = "textfield",
 
-  className,
+  classNamesObj = {},
   placeholder = undefined,
 
   onChange,
@@ -32,6 +46,8 @@ export const StandAloneTextfield = ({
   autoFocus = false,
   prefix = "",
   size = ComponentSize.MEDIUM,
+  standAloneTextfieldChildren,
+  standAloneTextfieldChildrenPosition = "right",
 }: StandAloneTextfieldProps) => {
   const textfieldWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -56,28 +72,38 @@ export const StandAloneTextfield = ({
 
       const inputStyles = window.getComputedStyle(inputElement);
 
-      const paddingLeft = prefixStyleProperties.prefixLeftPosition
-        ? prefixStyleProperties.prefixLeftPosition
-        : inputStyles.paddingLeft;
+      const inputPaddingLeft = inputStyles.paddingLeft;
+
+      const leftChildrenComponentWidth: number = getChildrenComponentWidth(
+        textfieldWrapperElement.querySelector(".standalone-textfield-children-wrapper.left")
+      );
 
       setPrefixStyleProperties({
-        inputPaddingLeft: parseInt(paddingLeft) * 2 + prefixWidth,
-        prefixLeftPosition: paddingLeft,
+        inputPaddingLeft: parseInt(inputPaddingLeft) * 2 + prefixWidth,
+        prefixLeftPosition: `${parseFloat(inputPaddingLeft) + leftChildrenComponentWidth}px`,
       });
     };
 
     prefix && calculateStyle();
-  }, [prefix, size]);
+  }, [prefix, size, standAloneTextfieldChildrenPosition, standAloneTextfieldChildren]);
+
+  const { standAloneTextfieldContainerClassName, prefixClassName, inputClassName } = classNamesObj;
 
   return (
     <div
       id={id ? `${idPrefix}-wrapper-${id}` : undefined}
       style={style}
       ref={textfieldWrapperRef}
-      className="standalone-textfield-wrapper"
+      className={classNames("standalone-textfield-wrapper", standAloneTextfieldContainerClassName)}
     >
+      {standAloneTextfieldChildrenPosition === "left" && (
+        <div className="standalone-textfield-children-wrapper left">{standAloneTextfieldChildren}</div>
+      )}
       {prefix && (
-        <span className="m-textfield-prefix" style={{ left: prefixStyleProperties.prefixLeftPosition }}>
+        <span
+          className={classNames("m-textfield-prefix", prefixClassName)}
+          style={{ left: prefixStyleProperties.prefixLeftPosition }}
+        >
           {prefix}
         </span>
       )}
@@ -86,7 +112,7 @@ export const StandAloneTextfield = ({
         readOnly={readOnly}
         disabled={disabled}
         name={name}
-        className={classNames("m-input", "m-textfield", className)}
+        className={classNames("m-input", "m-textfield", inputClassName)}
         type={type}
         style={prefix ? { paddingLeft: prefixStyleProperties.inputPaddingLeft } : undefined}
         value={value}
@@ -102,6 +128,9 @@ export const StandAloneTextfield = ({
           }
         }}
       />
+      {standAloneTextfieldChildrenPosition === "right" && (
+        <div className="standalone-textfield-children-wrapper right">{standAloneTextfieldChildren}</div>
+      )}
     </div>
   );
 };

--- a/src/components/Inputs/_inputsComponents/StandAloneTextfield/types.ts
+++ b/src/components/Inputs/_inputsComponents/StandAloneTextfield/types.ts
@@ -1,5 +1,11 @@
-import React, { ChangeEvent, CSSProperties, FocusEvent } from "react";
+import React, { ChangeEvent, CSSProperties, FocusEvent, ReactNode } from "react";
 import { InputProps } from "../input-types";
+
+export type StandAloneTextfieldClassNames = {
+  standAloneTextfieldContainerClassName?: string;
+  inputClassName?: string;
+  prefixClassName?: string;
+};
 
 export type TextfieldTypes = "text" | "number" | "password";
 
@@ -28,8 +34,8 @@ export type StandAloneTextfieldProps = Omit<
    * @default false */
   disableSubmitOnEnter?: boolean;
 
-  /** Additional CSS class names for custom styling. */
-  className?: string;
+  /** Custom class names for styling different elements of the component. */
+  classNamesObj?: StandAloneTextfieldClassNames;
 
   /** Optional text displayed before value in `TextField`. */
   prefix?: string;
@@ -55,4 +61,7 @@ export type StandAloneTextfieldProps = Omit<
   /** Prefix for the id attributes in `StandAloneTextfieldProps`.
    * @default "textfield" */
   idPrefix?: string;
+
+  standAloneTextfieldChildren?: ReactNode;
+  standAloneTextfieldChildrenPosition?: "left" | "right";
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized and renamed class name props across input components for improved clarity and consistency.
  - Updated components to use destructured class name objects, enabling more granular styling.
  - Enhanced performance and structure of ColorPicker, IconField, and StandAloneTextfield components with memoization and optimized rendering.
  - Simplified and improved handling of custom children and layout in StandAloneTextfield, supporting left/right positioning.
- **Style**
  - Updated styles for color and icon preview components to reflect structural changes and improve interaction feedback.
- **Documentation**
  - Updated story for ColorPicker to remove the default initial color value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->