### PR TITLE
feat: Add busy icon to the confirm btn in alert footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Release date ??.??.???? - Release ?.?.?
 
+- [[#266]](https://github.com/Marcin-Migdal/m-component-library/issues/266) **[PATCH]** Add busy icon to the confirm btn in alert footer
+
 ### Release date 15.02.2026 - Release 2.1.6
 
 - [[#250]](https://github.com/Marcin-Migdal/m-component-library/issues/250) **[PATCH]** Improve DropdownMenu to use DropdownSubMenu with template

--- a/src/components/Popups/Alerts/Alert.scss
+++ b/src/components/Popups/Alerts/Alert.scss
@@ -87,7 +87,17 @@
     }
 
     .m-alert-confirm-button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
       border-bottom-left-radius: var(--alert-border-radius);
+
+      .m-alert-confirm-button-busy-icon {
+        margin-right: var(--spacing-2);
+        width: 1rem;
+        height: 1rem;
+      }
 
       &:only-child {
         border-bottom-right-radius: var(--alert-border-radius);

--- a/src/components/Popups/Alerts/Alert.stories.tsx
+++ b/src/components/Popups/Alerts/Alert.stories.tsx
@@ -53,6 +53,11 @@ const meta: Meta<typeof Alert> = {
         defaultValue: { summary: "false" },
       },
     },
+    confirmBtnBusy: {
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
     declineBtnText: {
       table: {
         defaultValue: { summary: "Close" },

--- a/src/components/Popups/Alerts/components/AlertFooter.tsx
+++ b/src/components/Popups/Alerts/components/AlertFooter.tsx
@@ -15,26 +15,26 @@ export function AlertFooter<TData = undefined>({
   onDecline,
 }: AlertFooterProps<TData>) {
   useEffect(() => {
-    if (disableConfirmOnEnter) {
-      return;
-    }
-
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (onConfirm && event.code === "Enter") {
-        onConfirm(data as unknown as TData);
+      if (event.code === "Enter") {
+        if (confirmBtnBusy || confirmBtnDisabled || disableConfirmOnEnter) {
+          return;
+        }
+
+        if (onConfirm) {
+          event.preventDefault();
+          event.stopPropagation();
+          onConfirm(data as unknown as TData);
+        }
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      if (disableConfirmOnEnter) {
-        return;
-      }
-
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [disableConfirmOnEnter, onConfirm, data, confirmBtnBusy, confirmBtnDisabled]);
 
   if (!onConfirm && !onDecline) {
     return null;

--- a/src/components/Popups/Alerts/components/AlertFooter.tsx
+++ b/src/components/Popups/Alerts/components/AlertFooter.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from "react";
 
+import { Icon } from "../../../Miscellaneous/Icon";
 import { AlertFooterProps } from "../types";
 
 export function AlertFooter<TData = undefined>({
   data,
   confirmBtnText = "Confirm",
   confirmBtnDisabled = false,
+  confirmBtnBusy = false,
   disableConfirmOnEnter = false,
   onConfirm,
   declineBtnText = "Close",
@@ -42,10 +44,13 @@ export function AlertFooter<TData = undefined>({
     <div className="m-alert-footer">
       {onConfirm && (
         <button
-          disabled={confirmBtnDisabled}
+          disabled={confirmBtnDisabled || confirmBtnBusy}
           onClick={() => onConfirm(data as unknown as TData)}
           className="m-alert-confirm-button"
         >
+          {confirmBtnBusy && (
+            <Icon icon={["fas", "circle-notch"]} className="fa-spin m-alert-confirm-button-busy-icon" />
+          )}
           {confirmBtnText}
         </button>
       )}

--- a/src/components/Popups/Alerts/types.ts
+++ b/src/components/Popups/Alerts/types.ts
@@ -58,6 +58,10 @@ export type AlertFooterProps<TData = undefined> = {
   /** Function to execute when the confirm button is clicked. */
   onConfirm?: (data: TData) => void;
 
+  /** Whether the confirm button is in a "busy" state.
+   * @default false */
+  confirmBtnBusy?: boolean;
+
   /** If set to true, alert `onConfirm` callback will not be called when `enter` key is pressed */
   disableConfirmOnEnter?: boolean;
 
@@ -106,7 +110,7 @@ export type UseAlertOpenResult<TData = undefined> = TData extends undefined
         handleClose: () => void;
 
         data: undefined;
-      }
+      },
     ]
   : [
       /** Function to trigger the opening of the alert. */
@@ -121,5 +125,5 @@ export type UseAlertOpenResult<TData = undefined> = TData extends undefined
         handleClose: () => void;
 
         data: TData | undefined;
-      }
+      },
     ];


### PR DESCRIPTION
Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a busy/loading state for alert confirm buttons. When active, a spinning indicator displays on the button and automatically disables user interaction until the operation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->