### PR TITLE
Fix: add checked property to Form controlled register change result (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Release date ??.??.???? - Release ?.?.?
 
+- [[#264]](https://github.com/Marcin-Migdal/m-component-library/issues/264) **[PATCH]** Add checked property to Form's controlled register change result
 - [[#265]](https://github.com/Marcin-Migdal/m-component-library/issues/265) **[PATCH]** Imagefield add src prop to pass image url that should be displayed
 - [[#266]](https://github.com/Marcin-Migdal/m-component-library/issues/266) **[PATCH]** Add busy icon to the confirm btn in alert footer
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -53,11 +53,15 @@ function Form<TFormState extends FormikValues>({
     const translatedFieldErrors = t && fieldErrors ? translateErrors(fieldErrors, t) : fieldErrors;
 
     if (controlled) {
+      const value = values?.[name];
+      const checked = typeof value === "boolean" ? value : false;
+
       const controlledChangeRegisterResult: ControlledRegisterChangeResult<TName, TChangeEvent, TFormState> = {
         name,
         error: translatedFieldErrors,
         onBlur: handleBlur,
-        value: values?.[name],
+        value,
+        checked,
         onChange: handleChange,
         disableSubmitOnEnter,
       };

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -21,6 +21,7 @@ export type ControlledRegisterChangeResult<
   TFormState extends FormikValues,
 > = {
   value: TFormState[TName];
+  checked: boolean;
   onChange: (e: TChangeEvent) => void;
 } & BaseRegisterResult<TName, TChangeEvent, TFormState>;
 

--- a/src/components/Popups/Alerts/Alert.stories-schemas.tsx
+++ b/src/components/Popups/Alerts/Alert.stories-schemas.tsx
@@ -106,7 +106,7 @@ export const initFilledAlertInputsState: FilledAlertInputsState = {
   image: null,
   percentage: 30,
   remember: false,
-  darkMode: false,
+  darkMode: true,
 };
 
 export const filledAlertInputsStateSchema = Yup.object().shape({
@@ -141,7 +141,7 @@ export const filledAlertInputsStateSchema = Yup.object().shape({
   image: Yup.mixed<File>().nullable().required("Image is required"),
   percentage: Yup.number().min(20, "Percentage must be at least 20").default(30),
   remember: Yup.boolean().default(false),
-  darkMode: Yup.boolean().default(false),
+  darkMode: Yup.boolean().default(true),
 });
 
 export type FilledAlertInputsSubmitState = InferSchemaType<typeof filledAlertInputsStateSchema>;


### PR DESCRIPTION
Closes #264. Adds checked property to the Form's controlled register change result to support components like ToggleSwitch and Checkbox that rely on a checked boolean value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the Form component's controlled register functionality by adding a `checked` property to the change result object, improving support for boolean-type form fields with cleaner state management.

* **Chores**
  * Modified the default dark mode setting for alert components, now enabled by default.
  * Updated changelog to document recent patch improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->