### PR TITLE
feat: add disableSelection and disableExpansion props for Accordion component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Release date ??.??.???? - Release ?.?.?
 
+- [[#272]](https://github.com/Marcin-Migdal/m-component-library/issues/272) **[PATCH]** Add disableSelection and disableExpansion props to Accordion component
 - [[#264]](https://github.com/Marcin-Migdal/m-component-library/issues/264) **[PATCH]** Add checked property to Form's controlled register change result
 - [[#265]](https://github.com/Marcin-Migdal/m-component-library/issues/265) **[PATCH]** Imagefield add src prop to pass image url that should be displayed
 - [[#266]](https://github.com/Marcin-Migdal/m-component-library/issues/266) **[PATCH]** Add busy icon to the confirm btn in alert footer

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -363,6 +363,39 @@ export const expandOnIconClick: StoryObj<typeof Accordion> = {
   },
 };
 
+export const DisabledSections: StoryObj<typeof Accordion> = {
+  args: {
+    expansionMode: "multiple",
+    selectionMode: "multiple",
+    children: (
+      <>
+        <h2>Accordion expands on icon click</h2>
+        <Accordion.Section sectionId="1" disableSelection>
+          <Accordion.Toggle expandOnIconClick>Selection Disabled</Accordion.Toggle>
+          <Accordion.Content>
+            <Accordion.Item>Item 1 | 1</Accordion.Item>
+            <Accordion.Item>Item 1 | 2</Accordion.Item>
+          </Accordion.Content>
+        </Accordion.Section>
+        <Accordion.Section sectionId="2" disableExpansion>
+          <Accordion.Toggle expandOnIconClick>Expansion Disabled</Accordion.Toggle>
+          <Accordion.Content>
+            <Accordion.Item>Item 2 | 1</Accordion.Item>
+            <Accordion.Item>Item 2 | 2</Accordion.Item>
+          </Accordion.Content>
+        </Accordion.Section>
+        <Accordion.Section sectionId="3" disableSelection disableExpansion>
+          <Accordion.Toggle expandOnIconClick>Both Disabled</Accordion.Toggle>
+          <Accordion.Content>
+            <Accordion.Item>Item 3 | 1</Accordion.Item>
+            <Accordion.Item>Item 3 | 2</Accordion.Item>
+          </Accordion.Content>
+        </Accordion.Section>
+      </>
+    ),
+  },
+};
+
 export const CSSVariables: StoryObj = {
   render: () => <ComponentCssVariableTable data={cssVariablesData} />,
 };

--- a/src/components/Accordion/AccordionContent/AccordionContent.tsx
+++ b/src/components/Accordion/AccordionContent/AccordionContent.tsx
@@ -15,7 +15,7 @@ export const AccordionContent: React.FC<PropsWithChildren<AccordionContentProps>
   const ref = useRef<HTMLDivElement>(null);
 
   const { instanceClassName, expandAnimation } = useAccordion();
-  const { isExpanded } = useAccordionSection();
+  const { isExpanded, disableSelection, disableExpansion } = useAccordionSection();
 
   const [contentHeight, setContentHeight] = useState<number | undefined>(undefined);
 
@@ -58,6 +58,8 @@ export const AccordionContent: React.FC<PropsWithChildren<AccordionContentProps>
         ref={ref}
         className={classNames("m-accordion-content", className, {
           [`${instanceClassName}-content`]: !!instanceClassName,
+          "selection-disabled": disableSelection,
+          "expansion-disabled": disableExpansion,
         })}
       >
         {children}

--- a/src/components/Accordion/AccordionSection/AccordionSection.tsx
+++ b/src/components/Accordion/AccordionSection/AccordionSection.tsx
@@ -12,6 +12,8 @@ export const AccordionSection: React.FC<PropsWithChildren<AccordionSectionProps>
   children,
   sectionId,
   className,
+  disableSelection,
+  disableExpansion,
 }) => {
   const { selected, expanded, instanceClassName } = useAccordion();
 
@@ -24,7 +26,13 @@ export const AccordionSection: React.FC<PropsWithChildren<AccordionSectionProps>
         [`${instanceClassName}-section`]: !!instanceClassName,
       })}
     >
-      <AccordionSectionContextProvider sectionId={sectionId} isSelected={isSelected} isExpanded={isExpanded}>
+      <AccordionSectionContextProvider
+        sectionId={sectionId}
+        isSelected={isSelected}
+        isExpanded={isExpanded}
+        disableSelection={disableSelection}
+        disableExpansion={disableExpansion}
+      >
         {children}
       </AccordionSectionContextProvider>
     </div>

--- a/src/components/Accordion/AccordionSection/types.ts
+++ b/src/components/Accordion/AccordionSection/types.ts
@@ -1,4 +1,6 @@
 export type AccordionSectionProps = {
   sectionId: string;
   className?: string;
+  disableSelection?: boolean;
+  disableExpansion?: boolean;
 };

--- a/src/components/Accordion/AccordionToggle/AccordionToggle.tsx
+++ b/src/components/Accordion/AccordionToggle/AccordionToggle.tsx
@@ -30,7 +30,7 @@ export const AccordionToggle: React.FC<PropsWithChildren<AccordionToggleProps>> 
 
   const { sectionId, isExpanded, isSelected, disableSelection, disableExpansion } = useAccordionSection();
 
-  const icon: ToggleIconPosition = expansionMode === undefined ? "none" : localIcon ?? globalIcon;
+  const icon: ToggleIconPosition = expansionMode === undefined ? "none" : (localIcon ?? globalIcon);
   const expandOnIconClick = localExpandOnIconClick ?? globalExpandOnIconClick ?? false;
 
   const handleToggleClick = () => {
@@ -39,8 +39,9 @@ export const AccordionToggle: React.FC<PropsWithChildren<AccordionToggleProps>> 
   };
 
   const handleToggleIconClick = (event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+    event.stopPropagation();
+
     if (expandOnIconClick && !disableExpansion) {
-      event.stopPropagation();
       handleExpand(sectionId);
     }
   };

--- a/src/components/Accordion/AccordionToggle/AccordionToggle.tsx
+++ b/src/components/Accordion/AccordionToggle/AccordionToggle.tsx
@@ -28,18 +28,18 @@ export const AccordionToggle: React.FC<PropsWithChildren<AccordionToggleProps>> 
     globalExpandOnIconClick,
   } = useAccordion();
 
-  const { sectionId, isExpanded, isSelected } = useAccordionSection();
+  const { sectionId, isExpanded, isSelected, disableSelection, disableExpansion } = useAccordionSection();
 
   const icon: ToggleIconPosition = expansionMode === undefined ? "none" : localIcon ?? globalIcon;
   const expandOnIconClick = localExpandOnIconClick ?? globalExpandOnIconClick ?? false;
 
   const handleToggleClick = () => {
-    !expandOnIconClick && handleExpand(sectionId);
-    handleSelect(sectionId);
+    !disableExpansion && !expandOnIconClick && handleExpand(sectionId);
+    !disableSelection && handleSelect(sectionId);
   };
 
   const handleToggleIconClick = (event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-    if (expandOnIconClick) {
+    if (expandOnIconClick && !disableExpansion) {
       event.stopPropagation();
       handleExpand(sectionId);
     }
@@ -52,6 +52,8 @@ export const AccordionToggle: React.FC<PropsWithChildren<AccordionToggleProps>> 
         [`${instanceClassName}-toggle`]: !!instanceClassName,
         selected: isSelected,
         responsive: selectionMode !== undefined || expansionMode !== undefined,
+        "selection-disabled": disableSelection,
+        "expansion-disabled": disableExpansion,
       })}
       onClick={handleToggleClick}
     >

--- a/src/components/Accordion/context/AccordionSectionContext/AccordionSectionContext.tsx
+++ b/src/components/Accordion/context/AccordionSectionContext/AccordionSectionContext.tsx
@@ -6,6 +6,8 @@ export const AccordionSectionContext = createContext<AccordionSectionContextType
   sectionId: "",
   isSelected: false,
   isExpanded: false,
+  disableSelection: false,
+  disableExpansion: false,
 });
 
 export const AccordionSectionContextProvider = ({
@@ -13,6 +15,8 @@ export const AccordionSectionContextProvider = ({
   sectionId,
   isSelected,
   isExpanded,
+  disableSelection,
+  disableExpansion,
 }: PropsWithChildren<AccordionSectionContextProviderProps>) => {
   return (
     <AccordionSectionContext.Provider
@@ -20,6 +24,8 @@ export const AccordionSectionContextProvider = ({
         sectionId,
         isSelected,
         isExpanded,
+        disableSelection,
+        disableExpansion,
       }}
     >
       {children}

--- a/src/components/Accordion/context/AccordionSectionContext/types.ts
+++ b/src/components/Accordion/context/AccordionSectionContext/types.ts
@@ -2,10 +2,14 @@ export type AccordionSectionContextProviderProps = {
   sectionId: string;
   isSelected: boolean;
   isExpanded: boolean;
+  disableSelection?: boolean;
+  disableExpansion?: boolean;
 };
 
 export type AccordionSectionContextType = {
   sectionId: string;
   isSelected: boolean;
   isExpanded: boolean;
+  disableSelection?: boolean;
+  disableExpansion?: boolean;
 };


### PR DESCRIPTION
Resolves #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New configuration options for Accordion sections to independently disable selection and expansion, providing granular control over which sections users can interact with.

* **Documentation**
  * Added a new Storybook story demonstrating disabled interaction configurations for Accordion sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->